### PR TITLE
Increase size of image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,18 @@ addons:
 script:
 - sudo ./build.sh ArchLinuxARM-rpi-latest
 - sudo ./build.sh ArchLinuxARM-rpi-2-latest
-# sudo ./build.sh ArchLinuxARM-rpi-3-latest
+- sudo ./build.sh ArchLinuxARM-rpi-3-latest
 - sudo ./build.sh ArchLinuxARM-rpi-4-latest
+- sudo ./build.sh ArchLinuxARM-rpi-aarch64-latest
 deploy:
   provider: releases
-  api_key:
-    secure: puN1b67ctptLrrMznaHVBZm6I02635lo94BX0cMxMSlph1UwjoXCjlLTV3/JgaMmD4nLMv1Ln+po22LTK/thiKblymTRQtwgksyCu8+Or0IiMYCXb58+QTmW1ROVrVVJ9nus2647UjGkTSA3n6JpH55KxFmwpcHf7N/xWvOhRyLWmGdPRwyoqilWoAptsZYIXsucJv6suI3whlx/hfMDyNQKt0BGUNE+WerMg+obY5c4dgjb/0Kt8HheEtQ1fb6qUeoxN93JYOYX4LZldFwwXV77X1ce7yEzhGtAryhUZBKfC0+Axc2zy/Jvg192B0E427ZU/D0xpT8Wnk0MOyakSBL9I3D2PYq9NNM+uNwPo6g7u+WVtL5nVXrgJRxVa4pLpTooRD1Iy5Sv+YIfOevrWj9kkC4KAqv0qsiUBYIiq9pZ8LYZR04QR8p/P/Ns9qnEUuF7hqfnoIlKn00wd8gJZsdzDk5sz5yMlBnoQip4cyBWpY2CbyVxBinYML+crv7gw4X+99ufidzrKNalg8PPeQEgqby3ehTuvGBzFZHs1J6y1frkMbx0krTjh7lhdbrt1rXanXllZe9pxhwcL9iYXwydx+U6Vnvidx4wSXgrg24e7i87lKubvaXOdlx6sbsRcFXVGDoMj18wLDbHTLwyzTBHM9t85Y8+2+KtOxIrgvc=
+  api_key: '$GITHUB_TOKEN'
   file:
-  - ArchLinuxARM-rpi-latest.img.gz
-  - ArchLinuxARM-rpi-2-latest.img.gz
-  # ArchLinuxARM-rpi-3-latest.img.gz
-  - ArchLinuxARM-rpi-4-latest.img.gz
+  - ArchLinuxARM-rpi-latest.img.zip
+  - ArchLinuxARM-rpi-2-latest.img.zip
+  - ArchLinuxARM-rpi-3-latest.img.zip
+  - ArchLinuxARM-rpi-4-latest.img.zip
+  - ArchLinuxARM-rpi-aarch64-latest.img.zip
   skip_cleanup: true
   on:
     tags: true

--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,10 @@ tar xzf ${NAME}.tar.gz -C root . >/dev/null 2>&1
 sync
 mv root/boot/* boot
 
+if [ $NAME == "ArchLinuxARM-rpi-aarch64-latest" ]; then
+    sed -i 's/mmcblk0/mmcblk1/g' root/etc/fstab
+fi
+
 umount boot root
 rmdir boot root
 partx -d ${LOOP}
@@ -93,6 +97,7 @@ losetup -d ${LOOP}
 
 echo '################## make image ###########################'
 
+zip ${NAME}.img.zip ${NAME}.img
 gzip ${NAME}.img
 chmod a+rw ${NAME}.img.gz
 

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ echo '################## make partitions ######################'
 # 100M == 104857600B  == 204800S
 
 # Method 1
-dd if=/dev/zero of=${NAME}.img bs=1024 count=$((1024*1024))
+dd if=/dev/zero of=${NAME}.img bs=1024 count=$((2*1024*1024))
 
 # Method 2
 #fallocate -l 1G ${NAME}.img
@@ -45,7 +45,7 @@ n
 p
  
  
-+100M
++200M
 t
 c
 n


### PR DESCRIPTION
The tar extraction is failing because the image is too small. Increase the size of the image to allow the extraction to complete successfully.